### PR TITLE
Use vnode context as refresh point

### DIFF
--- a/index.js
+++ b/index.js
@@ -115,8 +115,8 @@ exports.reload = tryWrap(function (id, options) {
     newCtor.release()
   }
   record.instances.slice().forEach(function (instance) {
-    if (instance.$parent) {
-      instance.$parent.$forceUpdate()
+    if (instance.$vnode && instance.$vnode.context) {
+      instance.$vnode.context.$forceUpdate()
     } else {
       console.warn('Root or manually mounted instance modified. Full reload required.')
     }


### PR DESCRIPTION
fix vuejs/vue-loader#370

When content vnode in slot is updated, `$forceUpdate` its `$parent` will not refresh the component. This is because content component in slot is rendered outside of `$parent`.
Using `$vnode.context` will find the correct context that makes content component reload.

Test Example Repo: 
https://github.com/HerringtonDarkholme/slot-hot-reload-repro

In the example repo, when `child` is changed, `$forceUpdate`ing its `$parent`, which is `container` in this case, will not refresh `child`. `child` is rendered in `app`, and rendered vnode is passed to `container` as `slot` content. If we change `$parent` to `$vnode.context`, it correctly resolves to `app`.

For non-distributed component, its render context is just $parent. So this is a backward-compatible change.