### PR TITLE
Update deprecated webpack docs links to webpack 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ const myComponentOptions = {
 }
 
 // assuming Webpack's HMR API.
-// https://webpack.github.io/docs/hot-module-replacement.html
+// https://webpack.js.org/guides/hot-module-replacement/
 if (module.hot) {
   const api = require('vue-hot-reload-api')
   const Vue = require('vue')

--- a/README_zh.md
+++ b/README_zh.md
@@ -17,7 +17,7 @@ const myComponentOptions = {
 }
 
 // 检测 Webpack 的 HMR API
-// https://webpack.github.io/docs/hot-module-replacement.html
+// https://doc.webpack-china.org/guides/hot-module-replacement/
 if (module.hot) {
   const api = require('vue-hot-reload-api')
   const Vue = require('vue')


### PR DESCRIPTION
https://webpack.github.io/docs/ has now been deprecated. 
> webpack v1 is deprecated. We encourage all developers to upgrade to webpack 2.

This PR updates links to webpack docs in README example to the new and up to date webpack 2 docs.
I have also tried to link the relevant webpack docs for Chinese. Hope I didn't get something horribly wrong.