### PR TITLE
support functional root components

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -62,7 +62,7 @@ function makeOptionsHot(id, options) {
     const render = options.render
     options.render = (h, ctx) => {
       const instances = map[id].instances
-      if (instances.indexOf(ctx.parent) < 0) {
+      if (ctx && instances.indexOf(ctx.parent) < 0) {
         instances.push(ctx.parent)
       }
       return render(h, ctx)

--- a/test/test.js
+++ b/test/test.js
@@ -194,3 +194,17 @@ test(id5, done => {
     done()
   })
 })
+
+const id6 = 'rerender: mounted with functional root component'
+test(id6, done => {
+  const fComp = {
+    functional: true,
+    render: h => h('div', 'foo')
+  }
+
+  api.createRecord(id6, fComp)
+
+  const app = new Vue(fComp).$mount()
+  expect(app.$el.textContent).toBe('foo')
+  done()
+})


### PR DESCRIPTION
Hi. This is a regression fix for (13ba90f1c93feaf0fbc5ac85b3c2c5c0c683bb9c). The problem is if the root element passed to Vue options itself is a functional component, hot reload API will fail as it has no parent el. Other things about such usage seem normal with production builds.

I've added a simple failing test too.