### PR TITLE
init window if it does not exist

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,8 @@
 let Vue // late bind
 let version
+if (!window) { 
+  var window = {}; 
+}
 const map = (window.__VUE_HOT_MAP__ = Object.create(null))
 let installed = false
 let isBrowserify = false

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 let Vue // late bind
 let version
 if (!window) { 
-  var window = {}; 
+  const window = {}; 
 }
 const map = (window.__VUE_HOT_MAP__ = Object.create(null))
 let installed = false


### PR DESCRIPTION
We need to use the module in a mobile application and there's no window object, so can we initialise it if it is not present as otherwise we get a null reference object here)