### PR TITLE
fix: support non-browser environments

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 let Vue // late bind
 let version
-const map = (window.__VUE_HOT_MAP__ = Object.create(null))
+const map = ((typeof window !== 'undefined' && window || global).__VUE_HOT_MAP__ = Object.create(null))
 let installed = false
 let isBrowserify = false
 let initHookName = 'beforeCreate'
@@ -38,7 +38,7 @@ exports.install = (vue, browserify) => {
 
 exports.createRecord = (id, options) => {
   if(map[id]) return
-  
+
   let Ctor = null
   if (typeof options === 'function') {
     Ctor = options


### PR DESCRIPTION
**Summary**
Fallback to add the record map to the `global` object if `window` is not available.

**Motivation / Use Case**
I'm working on https://github.com/appcelerator/titanium-vue that allows the usage of Vue.js to create native mobile apps using Axway Titanium. This change is required to support hot reloading in our non-browser environment. Normal browser environments shouldn't be affected by this change.

// EDIT: similar to #70 but instead of initializing `window`, fallback to `global` which actually refers to the global var in most non-browser environments.