### PR TITLE
fix: argument order for _u() (close #73)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -256,7 +256,7 @@ function patchScopedSlots (instance) {
   if (!instance._u) return
   // https://github.com/vuejs/vue/blob/dev/src/core/instance/render-helpers/resolve-scoped-slots.js
   const original = instance._u
-  instance._u = slots => original(slots, true)
+  instance._u = slots => original(slots, null, true)
   return () => {
     instance._u = original
   }

--- a/src/index.js
+++ b/src/index.js
@@ -256,7 +256,15 @@ function patchScopedSlots (instance) {
   if (!instance._u) return
   // https://github.com/vuejs/vue/blob/dev/src/core/instance/render-helpers/resolve-scoped-slots.js
   const original = instance._u
-  instance._u = slots => original(slots, null, true)
+  instance._u = slots => {
+    try {
+      // 2.6.4 ~ 2.6.6
+      return original(slots, true)
+    } catch (e) {
+      // 2.5 / >= 2.6.7
+      return original(slots, null, true)
+    }
+  }
   return () => {
     instance._u = original
   }


### PR DESCRIPTION
In https://github.com/vuejs/vue/commit/7ec4627902020cccd7b3f4fbc63e1b0d6b9798cd, we changed the argument order of `_u()` to ensure backwards compatibility to Vue <2.6

We also have to make this change in the hot-reload-api

closes #73 