### PR TITLE
fix: fix hot-reload not working after options get modified

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -227,7 +227,7 @@ exports.reload = tryWrap((id, options) => {
       }
       const newCtor = record.Ctor.super.extend(options)
       // prevent record.options._Ctor from being overwritten accidentally
-      newCtor.options._Ctor = record.options._Ctor;
+      newCtor.options._Ctor = record.options._Ctor
       record.Ctor.options = newCtor.options
       record.Ctor.cid = newCtor.cid
       record.Ctor.prototype = newCtor.prototype

--- a/src/index.js
+++ b/src/index.js
@@ -226,6 +226,8 @@ exports.reload = tryWrap((id, options) => {
         record.Ctor.extendOptions = options
       }
       const newCtor = record.Ctor.super.extend(options)
+      // prevent record.options._Ctor from being overwritten accidentally
+      newCtor.options._Ctor = record.options._Ctor;
       record.Ctor.options = newCtor.options
       record.Ctor.cid = newCtor.cid
       record.Ctor.prototype = newCtor.prototype


### PR DESCRIPTION
Steps to reproduce:
1. clone this [repo](https://github.com/liximomo/vue-hrm-reproduction), start it in development mode.
2. change data `msg` in `src/app.vue`, hot reload works fine.
3. activate Vue Devtools panel in Chrome Devtools.
4. change data `msg` in `src/app.vue`, hot reload works fine.
5. change data `msg` in `src/app.vue` again, hot reload stop working.

What happened here?
Vue Devtools will patch the existed component options when it gets activated, which caused [this line](https://github.com/vuejs/vue/blob/0d2e9c46f16e9ec5bd0f3eebd2aa31c7f7493856/src/core/instance/init.js#L106) to be run. As a result, `record.options._Ctor` is now pointing to `newCtor.options._Ctor`, which breaks the connection between `record.Ctor` and `record.options` and cause hot-reload failure.
